### PR TITLE
Add branded SVG logo and wordmark styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,25 @@
   <body>
     <header class="site-header">
       <nav class="nav">
-        <div class="logo"><span>ai</span>.doo</div>
+        <div class="logo" aria-label="ai.doo">
+          <svg class="logo-mark" viewBox="0 0 64 64" role="img" aria-hidden="true">
+            <defs>
+              <linearGradient id="logo-gradient" x1="0" x2="1" y1="0" y2="1">
+                <stop offset="0%" stop-color="#1f5eff" />
+                <stop offset="100%" stop-color="#5b8bff" />
+              </linearGradient>
+            </defs>
+            <path
+              class="logo-head"
+              d="M32 8c-10.5 0-19 8.5-19 19 0 7.4 4.2 13.8 10.4 17l-.2 8.6c0 1.2 1 2.2 2.2 2.2h11.4c1.2 0 2.2-1 2.2-2.2v-6.4h6.2c4.1 0 7.4-3.3 7.4-7.4v-6.2C52.6 18.6 43.1 8 32 8z"
+            />
+            <path
+              class="logo-core"
+              d="M37.5 17.2c4.7 1.7 7.8 6.2 7.2 11.1-.5 4.7-4.1 8.5-8.9 9.2-6.1.9-11.5-3.8-11.5-9.8 0-6.8 6.6-12.7 13.2-10.5z"
+            />
+          </svg>
+          <span class="logo-wordmark"><span>ai</span>.doo</span>
+        </div>
         <div class="nav-links">
           <a href="#solutions">Solutions</a>
           <a href="#platform">Platform</a>
@@ -154,7 +172,25 @@
 
     <footer class="site-footer">
       <div class="footer-brand">
-        <div class="logo"><span>ai</span>.doo</div>
+        <div class="logo" aria-label="ai.doo">
+          <svg class="logo-mark" viewBox="0 0 64 64" role="img" aria-hidden="true">
+            <defs>
+              <linearGradient id="logo-gradient-footer" x1="0" x2="1" y1="0" y2="1">
+                <stop offset="0%" stop-color="#1f5eff" />
+                <stop offset="100%" stop-color="#5b8bff" />
+              </linearGradient>
+            </defs>
+            <path
+              class="logo-head"
+              d="M32 8c-10.5 0-19 8.5-19 19 0 7.4 4.2 13.8 10.4 17l-.2 8.6c0 1.2 1 2.2 2.2 2.2h11.4c1.2 0 2.2-1 2.2-2.2v-6.4h6.2c4.1 0 7.4-3.3 7.4-7.4v-6.2C52.6 18.6 43.1 8 32 8z"
+            />
+            <path
+              class="logo-core"
+              d="M37.5 17.2c4.7 1.7 7.8 6.2 7.2 11.1-.5 4.7-4.1 8.5-8.9 9.2-6.1.9-11.5-3.8-11.5-9.8 0-6.8 6.6-12.7 13.2-10.5z"
+            />
+          </svg>
+          <span class="logo-wordmark"><span>ai</span>.doo</span>
+        </div>
         <p>AI microservices built for trusted enterprise outcomes.</p>
       </div>
       <div class="footer-links">

--- a/styles.css
+++ b/styles.css
@@ -48,26 +48,48 @@ button {
 }
 
 .logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
   font-weight: 500;
   font-size: 1.4rem;
   letter-spacing: 0.02em;
+}
+
+.logo-mark {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+}
+
+.logo-head {
+  fill: #ffffff;
+  stroke: rgba(14, 19, 21, 0.2);
+  stroke-width: 1.4;
+}
+
+.logo-core {
+  fill: url(#logo-gradient);
+}
+
+.logo-wordmark {
   display: inline-flex;
   align-items: baseline;
+  gap: 6px;
 }
 
-.logo span {
+.logo-wordmark span {
   font-weight: 700;
   position: relative;
-  margin-right: 6px;
 }
 
-.logo span::after {
+.logo-wordmark span::after {
   content: "";
   position: absolute;
-  right: -10px;
-  bottom: 0.2em;
-  width: 6px;
-  height: 6px;
+  right: -12px;
+  bottom: 0.15em;
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
   background: var(--accent);
 }
@@ -320,6 +342,15 @@ main {
   gap: 30px;
   border-top: 1px solid var(--border);
   background: #f2f4f7;
+}
+
+.site-footer .logo-mark {
+  width: 40px;
+  height: 40px;
+}
+
+.site-footer .logo-core {
+  fill: url(#logo-gradient-footer);
 }
 
 .footer-brand p {


### PR DESCRIPTION
### Motivation
- Introduce a compact, modern logo treatment that matches the existing minimalist theme while giving `ai.doo` a distinct brand mark. 
- Keep typography, neutral palette, and layout intact while adding a scalable SVG mark usable in header and footer. 

### Description
- Embedded an inline SVG logo mark into the header and footer in `index.html` with accessible attributes (`aria-label`, `role="img"`, `aria-hidden`).
- Added gradient definitions (`#logo-gradient`, `#logo-gradient-footer`) and two SVG paths for the logo shape inside the markup in `index.html`.
- Extended `styles.css` with `.logo-mark`, `.logo-head`, `.logo-core`, and `.logo-wordmark` rules to size the mark, apply gradients, add a wordmark layout, and preserve the site accent via the small dot detail. 
- Added footer-specific overrides for the logo sizing and gradient fill to ensure visual consistency across components. 

### Testing
- Served the site locally with `python -m http.server` and rendered the homepage with a Playwright script that produced a screenshot artifact (`artifacts/ai-doo-home.png`), which completed successfully. 
- Visual inspection of the generated screenshot confirmed the logo appears in the header and footer as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773538493083318d8d0a0f4f971385)